### PR TITLE
Fix unexpected EOF error in bash subshell command

### DIFF
--- a/lib/helper/helper.go
+++ b/lib/helper/helper.go
@@ -141,7 +141,7 @@ func CreateSubShell(accountNumber string, accountAlias string, carName string, s
 		}
 		cmd = fmt.Sprintf(`ZDOTDIR=%v zsh`, zdotdir)
 	case "bash":
-		cmd = fmt.Sprintf(`bash --rcfile <(echo "source "$HOME/.bashrc; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
+		cmd = fmt.Sprintf(`bash --rcfile <(echo "source \"$HOME/.bashrc\"; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
 	default:
 		cmd = fmt.Sprintf(`bash --rcfile <(echo "source "$HOME/.bashrc; export PS1='[%v|%v] > '")`, accountAlias, accountNumber)
 	}


### PR DESCRIPTION
Correctly escape quotes in the bash subshell initiation command to prevent "unexpected EOF" errors when sourcing .bashrc and setting PS1.